### PR TITLE
:recycle: refactor: 웹 접근성 향상

### DIFF
--- a/src/components/search/SearchItem/index.tsx
+++ b/src/components/search/SearchItem/index.tsx
@@ -2,13 +2,14 @@ import SearchIcon from '@/components/common/Icon/SearchIcon';
 
 type SearchItemProps = {
   sickNm: string;
+  tabIndex: number;
 };
 
 const SearchItem = (props: SearchItemProps) => {
-  const { sickNm } = props;
+  const { sickNm, tabIndex } = props;
 
   return (
-    <li className="flex items-center py-2 px-7 hover:bg-slate-50">
+    <li tabIndex={tabIndex} className="flex items-center py-2 px-7 hover:bg-slate-50">
       <SearchIcon className="w-4 h-4 mr-3" />
       <span>{sickNm}</span>
     </li>

--- a/src/components/search/SearchList/index.tsx
+++ b/src/components/search/SearchList/index.tsx
@@ -23,7 +23,7 @@ const SearchList = (props: SearchList) => {
 
       <ul className="pt-3">
         {sicks.map((sick) => (
-          <SearchItem key={sick.sickCd} sickNm={sick.sickNm} />
+          <SearchItem key={sick.sickCd} tabIndex={0} sickNm={sick.sickNm} />
         ))}
       </ul>
     </div>


### PR DESCRIPTION
## 🎈 작업한 내용

- refactor: li 태그의 tabIndex를 통해 tab 버튼 입력 시 li 태그에 포커싱
 
### 💡 참고 사항
button의 tabIndex를 -1로 하여 포커싱을 방지할까 고민했으나, 버튼 태그에 키보드로만 접근하고자 하는 유저도 있을 수 있다고 판단하여 포커싱을 남겨두었음